### PR TITLE
add the main router functionality in the frontend

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,9 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { Analytics } from '@vercel/analytics/next'
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-})
 
 export const metadata: Metadata = {
   title: 'Wayfinder - Intelligent LLM Routing Control Plane',
@@ -38,7 +32,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} font-sans antialiased`}>
+      <body className="font-sans antialiased">
         <ThemeProvider>
           <div className="flex min-h-screen flex-col">
             <Header />

--- a/src/app/route/route.ts
+++ b/src/app/route/route.ts
@@ -1,0 +1,59 @@
+const stripTrailingSlash = (value: string) => value.replace(/\/$/, '')
+
+const buildRouteUrl = () => {
+  const baseUrl = process.env.API_BASE_URL
+  if (!baseUrl) return null
+  let base = stripTrailingSlash(baseUrl)
+  if (base.endsWith('/api')) {
+    base = base.slice(0, -4)
+  }
+  return `${base}/route`
+}
+
+const filterRequestHeaders = (headers: Headers) => {
+  const filtered = new Headers(headers)
+  filtered.delete('host')
+  filtered.delete('connection')
+  filtered.delete('content-length')
+  filtered.delete('accept-encoding')
+  filtered.delete('cookie')
+  filtered.delete('x-session-token')
+  return filtered
+}
+
+const buildResponseHeaders = (headers: Headers) => {
+  const passthrough = new Headers()
+  const contentType = headers.get('content-type')
+  if (contentType) passthrough.set('content-type', contentType)
+  ;['ratelimit-limit', 'ratelimit-remaining', 'ratelimit-reset', 'x-request-id'].forEach(
+    (key) => {
+      const value = headers.get(key)
+      if (value) passthrough.set(key, value)
+    }
+  )
+  return passthrough
+}
+
+export async function POST(request: Request) {
+  const target = buildRouteUrl()
+  if (!target) {
+    return new Response(JSON.stringify({ message: 'API_BASE_URL is not configured.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const body = await request.arrayBuffer()
+  const headers = filterRequestHeaders(request.headers)
+
+  const response = await fetch(target, {
+    method: 'POST',
+    headers,
+    body,
+  })
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: buildResponseHeaders(response.headers),
+  })
+}

--- a/src/components/console/UserAccessConsole.tsx
+++ b/src/components/console/UserAccessConsole.tsx
@@ -13,6 +13,7 @@ import {
   Lock,
   Plus,
   RefreshCw,
+  Send,
   ShieldX,
   Trash2,
 } from 'lucide-react'
@@ -24,6 +25,8 @@ type SignupStatus = 'idle' | 'loading' | 'success' | 'error'
 type LoginStatus = 'idle' | 'loading' | 'success' | 'error'
 
 type TokenActionStatus = 'idle' | 'loading' | 'success' | 'error'
+
+type RouteStatus = 'idle' | 'loading' | 'success' | 'error'
 
 type UserProfile = {
   email: string
@@ -67,6 +70,14 @@ type CreateTokenResponse = {
   }
 }
 
+type RouteResponse = {
+  primary?: { model?: string; score?: number; reason?: string }
+  alternate?: { model?: string; score?: number; reason?: string }
+  request_id?: string
+  router_model_used?: string
+  from_cache?: boolean
+}
+
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const formatDate = (value?: string | null) => {
@@ -89,6 +100,13 @@ export function UserAccessConsole() {
     const headers = options.headers instanceof Headers
       ? Object.fromEntries(options.headers.entries())
       : (options.headers as Record<string, string> | undefined)
+    if (headers) {
+      Object.keys(headers).forEach((key) => {
+        if (key.toLowerCase().includes('token')) {
+          headers[key] = '[redacted]'
+        }
+      })
+    }
     const body = typeof options.body === 'string' ? options.body : undefined
     console.info(`[console:${label}]`, { url, method: options.method, headers, body })
   }
@@ -117,6 +135,17 @@ export function UserAccessConsole() {
   const [newTokenModels, setNewTokenModels] = useState<string[]>([])
   const [expandedTokenId, setExpandedTokenId] = useState<string | null>(null)
   const [rotatedTokenSecrets, setRotatedTokenSecrets] = useState<Record<string, string>>({})
+
+  const [routeToken, setRouteToken] = useState('')
+  const [routePrompt, setRoutePrompt] = useState('')
+  const [routeContext, setRouteContext] = useState('')
+  const [routeMetadata, setRouteMetadata] = useState('')
+  const [routePreferModel, setRoutePreferModel] = useState('')
+  const [routeRouterModel, setRouteRouterModel] = useState('')
+  const [routeStatus, setRouteStatus] = useState<RouteStatus>('idle')
+  const [routeMessage, setRouteMessage] = useState('')
+  const [routeResponse, setRouteResponse] = useState<RouteResponse | null>(null)
+  const [rateLimitHeaders, setRateLimitHeaders] = useState<Record<string, string>>({})
 
   const [tokenMessage, setTokenMessage] = useState('')
 
@@ -498,6 +527,92 @@ export function UserAccessConsole() {
     } catch {
       setCreateMessage('Unable to create token. Check the model list and try again.')
       setCreateStatus('error')
+    }
+  }
+
+  const parseOptionalJson = (value: string, label: string) => {
+    if (!value.trim()) return { parsed: undefined as Record<string, unknown> | undefined }
+    try {
+      return { parsed: JSON.parse(value) as Record<string, unknown> }
+    } catch {
+      return { error: `${label} must be valid JSON.` }
+    }
+  }
+
+  const handleRouteRequest = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setRouteMessage('')
+    setRouteResponse(null)
+    setRateLimitHeaders({})
+
+    if (!routeToken.trim()) {
+      setRouteMessage('Add a Wayfinder token to send a route request.')
+      setRouteStatus('error')
+      return
+    }
+    if (!routePrompt.trim()) {
+      setRouteMessage('Prompt is required.')
+      setRouteStatus('error')
+      return
+    }
+
+    const parsedContext = parseOptionalJson(routeContext, 'Context')
+    if ('error' in parsedContext) {
+      setRouteMessage(parsedContext.error || 'Context must be valid JSON.')
+      setRouteStatus('error')
+      return
+    }
+    const parsedMetadata = parseOptionalJson(routeMetadata, 'Metadata')
+    if ('error' in parsedMetadata) {
+      setRouteMessage(parsedMetadata.error || 'Metadata must be valid JSON.')
+      setRouteStatus('error')
+      return
+    }
+
+    setRouteStatus('loading')
+
+    try {
+      const payload: Record<string, unknown> = {
+        prompt: routePrompt.trim(),
+      }
+      if (parsedContext.parsed) payload.context = parsedContext.parsed
+      if (parsedMetadata.parsed) payload.metadata = parsedMetadata.parsed
+      if (routePreferModel.trim()) payload.prefer_model = routePreferModel.trim()
+      if (routeRouterModel.trim()) payload.router_model = routeRouterModel.trim()
+
+      const url = '/route'
+      const options: RequestInit = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Wayfinder-Token': routeToken.trim(),
+        },
+        body: JSON.stringify(payload),
+      }
+      logRequest('route', url, options)
+      const response = await fetch(url, options)
+      const data = (await response.json().catch(() => null)) as RouteResponse | null
+
+      const rateHeaders: Record<string, string> = {}
+      ;['ratelimit-limit', 'ratelimit-remaining', 'ratelimit-reset', 'x-request-id'].forEach(
+        (key) => {
+          const value = response.headers.get(key)
+          if (value) rateHeaders[key] = value
+        }
+      )
+      setRateLimitHeaders(rateHeaders)
+
+      if (!response.ok || !data) {
+        setRouteMessage('Unable to route request. Check the token and payload.')
+        setRouteStatus('error')
+        return
+      }
+
+      setRouteResponse(data)
+      setRouteStatus('success')
+    } catch {
+      setRouteMessage('Unable to route request. Please try again.')
+      setRouteStatus('error')
     }
   }
 
@@ -886,6 +1001,18 @@ export function UserAccessConsole() {
                                   <Button
                                     type="button"
                                     variant="ghost"
+                                    onClick={() => {
+                                      const secret = rotatedTokenSecrets[token.id]
+                                      if (secret) {
+                                        setRouteToken(secret)
+                                      }
+                                    }}
+                                  >
+                                    Use in Route
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
                                     onClick={() =>
                                       setRotatedTokenSecrets((prev) => {
                                         const next = { ...prev }
@@ -910,6 +1037,187 @@ export function UserAccessConsole() {
                   <p className="mt-3 text-xs text-red-500" aria-live="polite">
                     {tokenMessage}
                   </p>
+                )}
+              </div>
+
+              <div className="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Route Playground</h3>
+                    <p className="mt-1 text-sm text-slate-500 dark:text-gray-400">
+                      Send a prompt to the router using a Wayfinder token. Requests are proxied server-side.
+                    </p>
+                  </div>
+                  <span className="text-xs text-slate-400">POST /route</span>
+                </div>
+
+                <form onSubmit={handleRouteRequest} className="mt-6 space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-token">
+                      Wayfinder token
+                    </label>
+                    <input
+                      id="route-token"
+                      type="password"
+                      value={routeToken}
+                      onChange={(event) => setRouteToken(event.target.value)}
+                      className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                      placeholder="wf_live_..."
+                      autoComplete="off"
+                    />
+                    <p className="mt-2 text-xs text-slate-500 dark:text-gray-400">
+                      Tokens are stored in memory only and never logged.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-prompt">
+                      Prompt
+                    </label>
+                    <textarea
+                      id="route-prompt"
+                      value={routePrompt}
+                      onChange={(event) => setRoutePrompt(event.target.value)}
+                      className="mt-2 min-h-[120px] w-full rounded-lg border border-slate-300 px-3 py-2 text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                      placeholder="Summarize the document..."
+                      required
+                    />
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-context">
+                        Context (JSON, optional)
+                      </label>
+                      <textarea
+                        id="route-context"
+                        value={routeContext}
+                        onChange={(event) => setRouteContext(event.target.value)}
+                        className="mt-2 min-h-[96px] w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-xs text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                        placeholder='{"doc_id":"123"}'
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-metadata">
+                        Metadata (JSON, optional)
+                      </label>
+                      <textarea
+                        id="route-metadata"
+                        value={routeMetadata}
+                        onChange={(event) => setRouteMetadata(event.target.value)}
+                        className="mt-2 min-h-[96px] w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-xs text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                        placeholder='{"team":"support"}'
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-prefer-model">
+                        Prefer model (optional)
+                      </label>
+                      <input
+                        id="route-prefer-model"
+                        type="text"
+                        value={routePreferModel}
+                        onChange={(event) => setRoutePreferModel(event.target.value)}
+                        className="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                        placeholder="gpt-4o-mini"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-200" htmlFor="route-router-model">
+                        Router override (optional)
+                      </label>
+                      <select
+                        id="route-router-model"
+                        value={routeRouterModel}
+                        onChange={(event) => setRouteRouterModel(event.target.value)}
+                        className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-gray-900 shadow-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-200 dark:border-gray-700 dark:bg-gray-950 dark:text-white"
+                      >
+                        <option value="">Auto</option>
+                        <option value="openai">openai</option>
+                        <option value="gemini">gemini</option>
+                        <option value="consensus">consensus</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button type="submit" className="gap-2" disabled={routeStatus === 'loading'}>
+                      <Send className="h-4 w-4" />
+                      {routeStatus === 'loading' ? 'Routing...' : 'Route prompt'}
+                    </Button>
+                    {routeMessage && (
+                      <p className="text-xs text-red-500" aria-live="polite">
+                        {routeMessage}
+                      </p>
+                    )}
+                  </div>
+                </form>
+
+                {(routeResponse || Object.keys(rateLimitHeaders).length > 0) && (
+                  <div className="mt-6 space-y-4 text-sm text-slate-700 dark:text-gray-300">
+                    {routeResponse && (
+                      <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-gray-800 dark:bg-gray-950">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <p className="font-semibold text-gray-900 dark:text-white">Response</p>
+                          {routeResponse.request_id && (
+                            <span className="text-xs text-slate-500">
+                              Request ID: {routeResponse.request_id}
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-3 grid gap-4 md:grid-cols-2">
+                          <div>
+                            <p className="text-xs uppercase text-slate-400">Primary</p>
+                            <p className="mt-1 font-semibold text-gray-900 dark:text-white">
+                              {routeResponse.primary?.model || '—'}
+                            </p>
+                            <p className="text-xs text-slate-500">
+                              Score: {routeResponse.primary?.score ?? '—'}
+                            </p>
+                            {routeResponse.primary?.reason && (
+                              <p className="mt-2 text-xs text-slate-600">{routeResponse.primary.reason}</p>
+                            )}
+                          </div>
+                          <div>
+                            <p className="text-xs uppercase text-slate-400">Alternate</p>
+                            <p className="mt-1 font-semibold text-gray-900 dark:text-white">
+                              {routeResponse.alternate?.model || '—'}
+                            </p>
+                            <p className="text-xs text-slate-500">
+                              Score: {routeResponse.alternate?.score ?? '—'}
+                            </p>
+                            {routeResponse.alternate?.reason && (
+                              <p className="mt-2 text-xs text-slate-600">{routeResponse.alternate.reason}</p>
+                            )}
+                          </div>
+                        </div>
+                        <div className="mt-4 flex flex-wrap gap-3 text-xs text-slate-500">
+                          <span>Router used: {routeResponse.router_model_used || '—'}</span>
+                          <span>From cache: {routeResponse.from_cache ? 'Yes' : 'No'}</span>
+                        </div>
+                        <div className="mt-4 rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-700 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-200">
+                          {JSON.stringify(routeResponse, null, 2)}
+                        </div>
+                      </div>
+                    )}
+
+                    {Object.keys(rateLimitHeaders).length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-4 text-xs text-slate-600 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-400">
+                        <p className="font-semibold text-gray-900 dark:text-white">Rate limit</p>
+                        <div className="mt-2 grid gap-2 md:grid-cols-2">
+                          {Object.entries(rateLimitHeaders).map(([key, value]) => (
+                            <div key={key} className="flex items-center justify-between gap-4">
+                              <span className="uppercase text-slate-400">{key}</span>
+                              <span className="font-mono text-slate-700 dark:text-gray-200">{value}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
 
@@ -1011,6 +1319,13 @@ export function UserAccessConsole() {
                           >
                             <Copy className="h-4 w-4" />
                             Copy
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={() => setRouteToken(newTokenSecret)}
+                          >
+                            Use in Route
                           </Button>
                         </div>
                         {newTokenModels.length > 0 && (


### PR DESCRIPTION
## Summary

  This PR adds end-to-end /route support to the frontend with a secure server-side proxy and an in-
  console testing UI.

  Users can now send routed prompt requests from /console without exposing backend host details or
  relying on cross-origin browser calls.

  ## What Changed

  ### 1) Added secure server-side /route proxy

  - New route handler: src/app/route/route.ts
  - Implements POST /route in Next.js and forwards to backend /route using API_BASE_URL
  - Preserves upstream status code and response body
  - Passes through routing/usage headers:
      - RateLimit-Limit
      - RateLimit-Remaining
      - RateLimit-Reset
      - X-Request-Id
  - Sanitizes forwarded headers and explicitly removes session/cookie headers (x-session-token, cookie,
    etc.)

  ### 2) Added Route Playground in user console

  - Updated: src/components/console/UserAccessConsole.tsx
  - New “Route Playground” section under /console that supports:
      - X-Wayfinder-Token entry
      - required prompt
      - optional context JSON
      - optional metadata JSON
      - optional prefer_model
      - optional router_model override (openai, gemini, consensus)
  - Displays:
      - primary + alternate model recommendations
      - router used
      - cache hit flag
      - request id
      - full JSON response
      - rate-limit headers
  - Includes validation for optional JSON fields before request submission
  - Added “Use in Route” actions next to newly-created and rotated tokens to speed up testing

  ### 3) Security/logging hardening

  - Dev logging now redacts any header containing token before printing request details
  - Keeps token handling memory-only in UI flow

  ### 4) Build reliability adjustment

  - Updated src/app/layout.tsx to remove Google-hosted Inter font import
  - Avoids build-time dependency on fonts.googleapis.com in restricted/isolated environments

  ## Why

  - Enables real product routing workflow from frontend to backend
  - Keeps /route effectively server-mediated for web app usage
  - Avoids CORS/header exposure issues for browser clients
  - Improves support/debug workflow with request-id and rate-limit visibility

  ## Configuration

  - Required env var: API_BASE_URL
  - Example:

    API_BASE_URL=https://<backend-host>
  - Proxy normalization handles trailing slash and /api base suffix when constructing backend /route

  ## Validation Performed

  - npm run build passes successfully
  - Route generation includes dynamic /route handler
  - Non-blocking pre-existing lint warnings remain in admin pages (react-hooks/exhaustive-deps)
